### PR TITLE
Canvas refresh bugs out increase wait time

### DIFF
--- a/src/events/pan_to_coordinate.py
+++ b/src/events/pan_to_coordinate.py
@@ -29,5 +29,5 @@ class PanToCoordinate:
 
         newRect = QgsRectangle(xMin,yMin,xMax,yMax)
         canvas.setExtent(newRect)
-        time.sleep(0.05) # Hack otherwise QGIS refresh bugs out
+        time.sleep(0.1) # Hack otherwise QGIS refresh bugs out
         canvas.refreshAllLayers()


### PR DESCRIPTION
Increases the wait time on canvas refresh after PanToCoordinate event from 0.05s to 0.1s
