### PR TITLE
better naming websocket

### DIFF
--- a/src/bridge_websocket.py
+++ b/src/bridge_websocket.py
@@ -5,9 +5,9 @@ from .libs import websocket
 import _thread as thread
 import time
 
-class ListenWebsocket(QtCore.QThread):
+class BridgeWebsocket(QtCore.QThread):
     def __init__(self, iface, parent=None):
-        super(ListenWebsocket, self).__init__(parent)
+        super(BridgeWebsocket, self).__init__(parent)
         self.iface = iface
         self.retries = 0
 

--- a/src/start.py
+++ b/src/start.py
@@ -6,7 +6,7 @@ from qgis.PyQt.QtCore import Qt, QUrl
 from qgis.core import QgsVectorLayer, QgsProject
 from qgis.gui import QgsMapCanvas, QgsHighlight
 from .resources import *
-from .listen_websockets import ListenWebsocket
+from .bridge_websocket import BridgeWebsocket
 from .application_settings import ApplicationSettings
 from .identify_select import IdentifySelect
 from .events.identify_network_element_handler import IdentifyNetworkElementHandler
@@ -21,7 +21,7 @@ class Start:
         self.autosave_enabled = False
         self.route_segment_layer = None
         self.route_node_layer = None
-        self.websocket = ListenWebsocket(self.iface)
+        self.websocket = BridgeWebsocket(self.iface)
         self.websocket.start()
         self.identifyHighlight = None
         self.identifyNetworkElementHandler = IdentifyNetworkElementHandler(self.websocket)


### PR DESCRIPTION
better naming of websocket class - renamed to BridgeWebsocket to
reflect that it is used in interaction with the bridge server.
