### PR TITLE
sets the default config to openftth.local

### DIFF
--- a/src/application_settings.py
+++ b/src/application_settings.py
@@ -1,5 +1,6 @@
 import os
-from configparser import ConfigParser 
+from configparser import ConfigParser
+
 
 class ApplicationSettings:
     def __init__(self):

--- a/src/config_copy.ini
+++ b/src/config_copy.ini
@@ -1,12 +1,12 @@
 [websocket]
-url = ws://localhost:5000/ws
+url = ws://desktop-bridge.openftth.local/ws
 
 [layers]
 routesegment = route_segment
 routenode = route_node
 
 [website]
-url = http://localhost:3000
+url = http://openftth.local
 
 [types]
 routesegment = RouteSegment


### PR DESCRIPTION
Now uses `openftth.local` to reflect the changes in the default setup in the openftth-chart.