### PR TITLE
disables trace from websocket to avoid missing logging dependency

### DIFF
--- a/src/bridge_websocket.py
+++ b/src/bridge_websocket.py
@@ -11,8 +11,6 @@ class BridgeWebsocket(QtCore.QThread):
         self.iface = iface
         self.retries = 0
 
-        websocket.enableTrace(True)
-
         self.websocket = websocket.WebSocketApp(ApplicationSettings().get_websocket_url(),
                                 on_message = lambda ws,msg: self.onMessage(ws, msg),
                                 on_error = lambda ws,msg: self.onError(ws, msg),


### PR DESCRIPTION
Removes the trace logging from websocket to avoid issue with missing logging dependency on clients.